### PR TITLE
Update RefreshListView.js

### DIFF
--- a/Chapter4-PullRefresh/PullRefreshExample/src/Refresh/RefreshListView.js
+++ b/Chapter4-PullRefresh/PullRefreshExample/src/Refresh/RefreshListView.js
@@ -52,6 +52,12 @@ export default class RefreshListView extends Component {
   /// 开始下拉刷新
   beginHeaderRefresh() {
     if (this.shouldStartHeaderRefreshing()) {
+      const nowTimestamp = new Date().getTime();
+      const subTimestamp = nowTimestamp - this.lastTimesttamp;
+      if (subTimestamp < 500) {
+        return;
+      }
+      this.lastTimesttamp = new Date().getTime();
       this.startHeaderRefreshing();
     }
   }
@@ -59,6 +65,12 @@ export default class RefreshListView extends Component {
   /// 开始上拉加载更多
   beginFooterRefresh() {
     if (this.shouldStartFooterRefreshing()) {
+      const nowTimestamp = new Date().getTime();
+      const subTimestamp = nowTimestamp - this.lastTimesttamp;
+      if (subTimestamp < 500) {
+        return;
+      }
+      this.lastTimesttamp = new Date().getTime();
       this.startFooterRefreshing();
     }
   }


### PR DESCRIPTION
fix: 列表初次加载，会多次刷新，有时两次刷新的时间间隔会大于网络请求的时间，这时会造成进行多次网络请求。 使用时间戳来使500毫秒内只会触发一次网络请求。